### PR TITLE
Feature: choose tracks to scrobble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 build
 coverage.xml
 dist
+.DS_Store

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+0.2.0 (TBD)
+    * `--track-choice` option to select a subset of tracks to scrobble.
 0.1.0 (2023-08-02):
     * Initial release on GitHub and PyPI.
     * `scrobble` is intended to be a general/omni-scrobbling tool that works with different tracklists.

--- a/src/scrobble/utils.py
+++ b/src/scrobble/utils.py
@@ -121,8 +121,12 @@ def choose_tracks(tracks: list[Track]) -> list[Track]:
         pre_selections = ','.join(['"' + track_str + '"' for track_str in track_dict.keys()])
         picked_tracks = subprocess.check_output(
             f"{gum_path} choose {choices} --no-limit --selected={pre_selections}",
+            env={'GUM_CHOOSE_HEIGHT': str(len(tracks))},
             shell=True,
             encoding='UTF-8').rstrip()
+
+        return [track for track in tracks if str(track) in picked_tracks]
+
     else:
         raise NotImplementedError("Track choosing without charmbracelet/gum installation is not implemented yet.")
 

--- a/src/scrobble/utils.py
+++ b/src/scrobble/utils.py
@@ -99,13 +99,14 @@ def prepare_tracks(cd: CD, tracks: list[Track], playbackend: str = 'now') -> lis
 
     return prepped_tracks
 
+
 def find_command(command: str):
     try:
         command_check = subprocess.check_output(
             f'which {command}',
             shell=True,
             encoding='UTF-8'
-            ).rstrip()
+        ).rstrip()
     except subprocess.CalledProcessError:
         command_check = None
 
@@ -116,12 +117,13 @@ def choose_tracks(tracks: list[Track]) -> list[Track]:
     gum_path = find_command('gum')
     if gum_path:
         track_dict: dict = {str(track): track for track in tracks}
-        choices = ' '.join(['"'+track_str+'"' for track_str in track_dict.keys()])
+        choices = ' '.join(['"' + track_str + '"' for track_str in track_dict.keys()])
+        pre_selections = ','.join(['"' + track_str + '"' for track_str in track_dict.keys()])
         picked_tracks = subprocess.check_output(
-                f"{gum_path} choose {choices} --no-limit",
-                shell=True,
-                encoding='UTF-8').rstrip()
+            f"{gum_path} choose {choices} --no-limit --selected={pre_selections}",
+            shell=True,
+            encoding='UTF-8').rstrip()
     else:
-        raise NotImplementedError("Haven't implemented basic choosing yet")
+        raise NotImplementedError("Track choosing without charmbracelet/gum installation is not implemented yet.")
 
     return [track for track in tracks if str(track) in picked_tracks]

--- a/tests/test__cd.py
+++ b/tests/test__cd.py
@@ -8,7 +8,7 @@ USERAGENT = UserAgent('scrobble (PyPI) (tests)',
                       )
 
 init_musicbrainz(USERAGENT)
-test_cd = CD.find_cd(727701816029, choice=False)
+test_cd = CD.find_cd(7277017746006, choice=False)
 
 
 def test_cd_artist():
@@ -18,4 +18,4 @@ def test_cd_album():
     assert test_cd.title == 'Comalies'
 
 def test_cd_track_length():
-    assert len(test_cd) == 13
+    assert len(test_cd) == 14

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,5 +1,16 @@
-import pytest
-from scrobble.utils import Config, find_command
+import unittest
+from unittest.mock import patch
+
+from scrobble.utils import Config, find_command, choose_tracks
+from scrobble.musicbrainz import Track
+from typing import List
+
+
+TEST_TRACKS: List[Track] = [
+            Track(track_title="track1", disc_no=1, track_position=1, track_length=10),
+            Track(track_title="track1", disc_no=1, track_position=2, track_length=20),
+            Track(track_title="track1", disc_no=1, track_position=3, track_length=30),
+        ]
 
 def test_valid_config_has_lastfm_api():
     test_config = Config(config_path='tests/resources/scrobble_complete_valid.toml')
@@ -24,3 +35,34 @@ def test_find_command_succeeding():
 def test_find_command_returning_none():
     bad_command_check = find_command('badfakecommand')
     assert bad_command_check is None
+
+
+class TestChooseTracksFunction(unittest.TestCase):
+    @patch('scrobble.utils.find_command')
+    @patch('subprocess.check_output')
+    def test_choose_tracks_with_gum(self, mock_check_output, mock_find_command):
+        mock_find_command.side_effect = lambda *args, **kwargs: '/path/to/gum'
+        mock_check_output.return_value = f"{str(TEST_TRACKS[0])},{str(TEST_TRACKS[1])}"
+
+        # Call the function
+        result = choose_tracks(TEST_TRACKS)
+
+        # Assert that the subprocess.check_output was called with the correct arguments
+        mock_check_output.assert_called_once_with(
+            f'/path/to/gum choose "{str(TEST_TRACKS[0])}" "{str(TEST_TRACKS[1])}" "{str(TEST_TRACKS[2])}"'
+            f' --no-limit --selected="{str(TEST_TRACKS[0])}","{str(TEST_TRACKS[1])}","{str(TEST_TRACKS[2])}"',
+            env={'GUM_CHOOSE_HEIGHT': '3'},
+            shell=True,
+            encoding='UTF-8'
+        )
+
+        # Assert that the result is as expected
+        self.assertEqual(result, [TEST_TRACKS[0], TEST_TRACKS[1]])
+
+    @patch('scrobble.utils.find_command')
+    def test_choose_tracks_without_gum(self, mock_find_command):
+        mock_find_command.return_value = None
+
+        # Call the function and expect NotImplementedError to be raised
+        with self.assertRaises(NotImplementedError):
+            choose_tracks(TEST_TRACKS)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,5 +1,5 @@
 import pytest
-from scrobble.utils import Config
+from scrobble.utils import Config, find_command
 
 def test_valid_config_has_lastfm_api():
     test_config = Config(config_path='tests/resources/scrobble_complete_valid.toml')
@@ -16,3 +16,11 @@ def test_valid_config_lastfm_api_key():
 def test_valid_config_lastfm_username():
     test_config = Config(config_path='tests/resources/scrobble_complete_valid.toml')
     assert test_config.lastfm_username == 'thespeckofme'
+
+def test_find_command_succeeding():
+    command_check = find_command('ls')
+    assert command_check is not None
+
+def test_find_command_returning_none():
+    bad_command_check = find_command('badfakecommand')
+    assert bad_command_check is None


### PR DESCRIPTION
Adds a `--track-choice` flag that lets the user select a subset of tracks to scrobble. Relies on [charmbracelet/gum](https://github.com/charmbracelet/gum) to select tracks in the command line for now.